### PR TITLE
feat: update pyinstaller build

### DIFF
--- a/src/aali/flowkit/__main__.py
+++ b/src/aali/flowkit/__main__.py
@@ -28,8 +28,8 @@ try:
 except ImportError:
     raise ImportError("Please install uvicorn to run the service: pip install aali-flowkit-python[all]")
 import argparse
-from urllib.parse import urlparse
 import multiprocessing
+from urllib.parse import urlparse
 
 
 def parse_cli_args():

--- a/src/aali/flowkit/__main__.py
+++ b/src/aali/flowkit/__main__.py
@@ -29,6 +29,7 @@ except ImportError:
     raise ImportError("Please install uvicorn to run the service: pip install aali-flowkit-python[all]")
 import argparse
 from urllib.parse import urlparse
+import multiprocessing
 
 
 def parse_cli_args():
@@ -98,4 +99,5 @@ def main():
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     main()

--- a/src/aali/flowkit/config/_config.py
+++ b/src/aali/flowkit/config/_config.py
@@ -84,7 +84,7 @@ class Config:
             raise ValueError("FLOWKIT_PYTHON_API_KEY is missing in the configuration file.")
 
     def _load_config(self, config_path: str) -> dict:
-        """Read the YAML configuration file, while handling the PyInstaller frozen mode.
+        """Read the YAML configuration file.
 
         Parameters
         ----------
@@ -99,7 +99,7 @@ class Config:
         Raises
         ------
         FileNotFoundError
-            If the configuration file is not found at any valid path.
+            If the configuration file is not found at any given path.
         """
         search_paths: list[Path] = []
 

--- a/src/aali/flowkit/config/_config.py
+++ b/src/aali/flowkit/config/_config.py
@@ -25,7 +25,6 @@
 import json
 import os
 from pathlib import Path
-import sys
 
 from azure.identity import ManagedIdentityCredential
 from azure.keyvault.secrets import SecretClient
@@ -61,7 +60,7 @@ class Config:
             configuration file.
 
         """
-        config_path = os.getenv("Aali_CONFIG_PATH", "config.yaml")
+        config_path = os.getenv("AALI_CONFIG_PATH", os.getenv("Aali_CONFIG_PATH", "config.yaml"))
         self._yaml = self._load_config(config_path)
 
         # Define the configuration variables to be parsed from the YAML file
@@ -102,20 +101,13 @@ class Config:
         FileNotFoundError
             If the configuration file is not found at any valid path.
         """
-        search_paths = []
+        search_paths: list[Path] = []
 
         # 1. Use explicitly set path first
         if config_path:
             search_paths.append(Path(config_path))
 
-        # 2. Use bundled path if running in a PyInstaller binary
-        if getattr(sys, "frozen", False):
-            base_dir = Path(sys.executable).resolve().parent
-            # To help with pyinstaller packaging, for the aali standalone installer
-            search_paths.append(base_dir / "configs" / "config.yaml")
-            search_paths.append(base_dir / "config.yaml")
-
-        # 3. Fallbacks for local dev
+        # 2. Fallbacks for local dev
         search_paths.append(Path("configs/config.yaml"))
         search_paths.append(Path("../../configs/config.yaml"))
 

--- a/src/aali/flowkit/config/_config.py
+++ b/src/aali/flowkit/config/_config.py
@@ -110,7 +110,6 @@ class Config:
 
         # 2. Use bundled path if running in a PyInstaller binary
         if getattr(sys, 'frozen', False):
-            # base_dir = Path(sys._MEIPASS)  # type: ignore[attr-defined]
             base_dir =  Path(sys.executable).resolve().parent
             # To help with pyinstaller packaging, for the aali standalone installer
             search_paths.append(base_dir / "configs" / "config.yaml")

--- a/src/aali/flowkit/config/_config.py
+++ b/src/aali/flowkit/config/_config.py
@@ -24,8 +24,8 @@
 
 import json
 import os
-import sys
 from pathlib import Path
+import sys
 
 from azure.identity import ManagedIdentityCredential
 from azure.keyvault.secrets import SecretClient
@@ -109,8 +109,8 @@ class Config:
             search_paths.append(Path(config_path))
 
         # 2. Use bundled path if running in a PyInstaller binary
-        if getattr(sys, 'frozen', False):
-            base_dir =  Path(sys.executable).resolve().parent
+        if getattr(sys, "frozen", False):
+            base_dir = Path(sys.executable).resolve().parent
             # To help with pyinstaller packaging, for the aali standalone installer
             search_paths.append(base_dir / "configs" / "config.yaml")
             search_paths.append(base_dir / "config.yaml")


### PR DESCRIPTION
Pyinstaller generally does not handle multiprocessing well in a frozen state, if the `freeze_support()` method is not declared. In addition, the `_load_config` method was updated to better support work on the installer